### PR TITLE
Allow custom httpc request options to be set

### DIFF
--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -42,6 +42,8 @@ defmodule NewRelic.Util.HTTP do
   https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
   """
   def http_options(opts \\ []) do
+    env_opts = Application.get_env(:new_relic_agent, :httpc_request_options, [])
+
     [
       connect_timeout: 1000,
       ssl: [
@@ -53,5 +55,6 @@ defmodule NewRelic.Util.HTTP do
       ]
     ]
     |> Keyword.merge(opts)
+    |> Keyword.merge(env_opts)
   end
 end


### PR DESCRIPTION
We're seeing http connection timeouts due to slow server responses. This
allows users to define custom configuration for the httpc request
options so they can pass in a timeout that is relevant for their servers.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
